### PR TITLE
Fix compilation for nightly 2018-08-28

### DIFF
--- a/src/mod.rs
+++ b/src/mod.rs
@@ -230,8 +230,10 @@ impl<'a> visit::Visitor<'a> for StupidVisitor {
 }
 
 fn main() {
-    // Grab the command line arguments.
-    let args: Vec<_> = std::env::args().collect();
-    // Run the compiler. Yep, that's it.
-    rustc_driver::run_compiler(&args, box StupidCalls::new(), None, None);
+    rustc_driver::run(|| {
+        // Grab the command line arguments.
+        let args: Vec<_> = std::env::args().collect();
+        // Run the compiler. Yep, that's it.
+        rustc_driver::run_compiler(&args, box StupidCalls::new(), None, None)
+    });
 }


### PR DESCRIPTION
Since [this](https://github.com/rust-lang/rust/commit/bd04796d6e7d7fbbc891edd28d4b6fdd02496180#diff-707a0eda6b2f1a0537abc3d23133748c) change, just calling `run_compiler` resulted in *thread 'main' panicked at 'cannot access a scoped thread local variable without calling `set` first'* error. My first fix was to wrap it with `syntax::with_globals` but it seemed to me as a magic code which would need some explanation. Hence I wrapped it with `rustc_driver::run` which seems more intuitive. I hope it is a correct fix.